### PR TITLE
Chore: Constant 폴더 구조 변경 (SimpleInput PR 후속 작업)

### DIFF
--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -3,7 +3,7 @@ import { styled } from 'stitches.config';
 import Link from 'next/link';
 import Button from './common/Button';
 import { H4 } from './heading';
-import { NavBarMenus, PyConNavList } from './constants';
+import { NavBarMenus, Routes } from '../constants/routes';
 
 const StyledNavArea = styled('div', {
   width: '74.6rem',
@@ -16,7 +16,7 @@ const StyledNavArea = styled('div', {
 
 const Body = styled('p', {
   bodyText: 1,
-  color: '$textPrimary',
+  color: '$white',
 });
 
 const StyledMenuBox = styled('div', {
@@ -31,8 +31,8 @@ const StyledMenu = styled('div', {
 const NavBar = () => {
   return (
     <StyledNavArea>
-      <Link href={PyConNavList.HOME.route} passHref>
-        <H4>{PyConNavList.HOME.title}</H4>
+      <Link href={Routes.HOME.route} passHref>
+        <H4>{Routes.HOME.title}</H4>
       </Link>
       <StyledMenuBox>
         {
@@ -45,8 +45,8 @@ const NavBar = () => {
           ))
         }
       </StyledMenuBox>
-      <Link href={PyConNavList.SPONSOR_JOIN.route} passHref>
-        <Button>{PyConNavList.SPONSOR_JOIN.title}</Button>
+      <Link href={Routes.SPONSOR_JOIN.route} passHref>
+        <Button>{Routes.SPONSOR_JOIN.title}</Button>
       </Link>
     </StyledNavArea>
   );

--- a/constants/routes.ts
+++ b/constants/routes.ts
@@ -1,4 +1,4 @@
-export const PyConNavList = {
+export const Routes = {
     HOME: {
         title: 'PyConKR',
         route: '/',
@@ -18,6 +18,6 @@ export const PyConNavList = {
 };
 
 export const NavBarMenus = [
-  PyConNavList.COC,
-  PyConNavList.SPONSOR_INFO,
+    Routes.COC,
+    Routes.SPONSOR_INFO,
 ];

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -15,6 +15,7 @@ import { ComponentProps, useState } from 'react';
 import Toggle from '@/components/Toggle';
 import { Progressbar } from '@/components/common/Progressbar';
 import { FileUpload } from '@/components/common';
+import NavBar from '@/components/NavBar';
 
 const Home: NextPage = () => {
   const [count, setCount] = useRecoilState<number>(sampleCountState);


### PR DESCRIPTION
라우트를 정의하고 있는 파일 용도를 더 잘 파악할 수 있도록 constants/routes.ts 파일로 폴더 구조와 파일명을 변경했습니다.