### PR TITLE
이미지 캐러셀 화살표 작동하게 만들기

### DIFF
--- a/components/sponsor/information/Guide.tsx
+++ b/components/sponsor/information/Guide.tsx
@@ -1,5 +1,5 @@
-import React, { useRef } from 'react';
-import Flicking from '@egjs/flicking';
+import React, { RefObject, useRef } from 'react';
+import Flicking from '@egjs/react-flicking';
 import { H1 } from '@/components/heading';
 import { SponsorSimpleCard } from './SponsorSimpleCard';
 import { ImageCardProps, SimpleCardProps } from './types';
@@ -27,16 +27,23 @@ const ArrowBackIcon = styled(ArrowBack, {
 });
 
 export const Guide = () => {
-  // TODO: 화살표 버튼 클릭해도 캐러셀 작동하게 만들기. Type 설정..!
-  const flickingRef = useRef<Flicking>(null);
-  const moveToForward = async () => {
-    if (flickingRef.current) {
-      await flickingRef.current.prev();
+  const flickingRef: RefObject<Flicking> | null = useRef(null);
+
+  const moveToPrevImages = () => {
+    const current = flickingRef.current;
+    if (current) {
+      const animationCtx = current.control.controller.animatingContext;
+      if (animationCtx.start || animationCtx.end) return;
+      current.prev();
     }
   };
-  const moveToNext = async () => {
-    if (flickingRef.current) {
-      await flickingRef.current.next();
+
+  const moveToNextImages = () => {
+    const current = flickingRef.current;
+    if (current) {
+      const animationCtx = current.control.controller.animatingContext;
+      if (animationCtx.start || animationCtx.end) return;
+      current.next();
     }
   };
 
@@ -61,12 +68,12 @@ export const Guide = () => {
       </S.Section>
       <S.SectionWithSidePadding id="benefits">
         <S.ArrowWrapper>
-          <ArrowBackIcon width="60" height="60" onClick={moveToForward} />
-          <ArrowForwardIcon width="60" height="60" onClick={moveToNext} />
+          <ArrowBackIcon width="60" height="60" onClick={moveToPrevImages} />
+          <ArrowForwardIcon width="60" height="60" onClick={moveToNextImages} />
         </S.ArrowWrapper>
         <H1>후원사 혜택</H1>
         <CarouselWrapper>
-          <SponsorCarousel>
+          <SponsorCarousel flickingRef={flickingRef}>
             {BENEFITS.map((benefit: ImageCardProps) => (
               <SponsorImageCard
                 key={benefit.id}

--- a/components/sponsor/information/SponsorCarousel.tsx
+++ b/components/sponsor/information/SponsorCarousel.tsx
@@ -1,19 +1,19 @@
-import { LegacyRef } from 'react';
+import { RefObject } from 'react';
 import Flicking from '@egjs/react-flicking';
 import '@egjs/react-flicking/dist/flicking-inline.css';
 import '@egjs/react-flicking/dist/flicking.css';
 
 type SponsorCarouselProps = {
-  ref?: LegacyRef<Flicking>;
+  flickingRef: RefObject<Flicking> | null;
 };
 
 const SponsorCarousel = ({
-  ref,
+  flickingRef,
   children,
 }: React.PropsWithChildren<SponsorCarouselProps>) => {
   return (
     <Flicking
-      ref={ref}
+      ref={flickingRef}
       viewportTag="div"
       align="prev"
       horizontal


### PR DESCRIPTION
- 이미지 캐러셀에서 화살표 클릭시 이동하도록 수정했습니다.
- 드래그 했을때 애니메이션 이벤트와 화살표 클릭시 이동하는 함수가 겹치면 에러가 발생하는 이슈가 있었는데, 애니메이션 시작과 끝점을 감지해서 그 시점에는 이동하지 않도록 방지 코드를 추가했습니다.