### PR TITLE
feat: 모바일 레이아웃

### DIFF
--- a/components/layout/SubNavBar.tsx
+++ b/components/layout/SubNavBar.tsx
@@ -7,8 +7,19 @@ import { RouteType } from '@/interfaces/RouteType';
 
 const SubNavBarList = styled('div', {
   display: 'flex',
-  flexDirection: 'column',
+  flexDirection: 'row',
+  flexWrap: 'wrap',
   flexShrink: 0,
+  placeContent: 'space-between',
+  overflow: 'hidden',
+  gap: 16,
+
+  '@bp2': {
+    flexDirection: 'column',
+    placeContent: 'normal',
+    overflow: 'auto',
+    gap: 24,
+  },
 });
 
 const SubNavBarListItem = styled(Link, {
@@ -23,9 +34,6 @@ const SubNavBarListItem = styled(Link, {
   },
   '&:hover': {
     color: '$textPrimary',
-  },
-  '&+&': {
-    marginTop: '24px',
   },
 });
 

--- a/components/main/Teaser.tsx
+++ b/components/main/Teaser.tsx
@@ -1,19 +1,49 @@
 import React from 'react';
-import { styled } from 'stitches.config';
+import { css, styled } from 'stitches.config';
 
 const TextBox = styled('div', {
   fontSize: '80px',
   fontWeight: 'bold',
-  paddingTop: 220,
+  paddingTop: 80,
   paddingLeft: 40,
+  paddingRight: 40,
   height: 'calc(100vh - 80px)',
+
+  '@bp2': {
+    paddingTop: 220,
+  },
+});
+
+const Title = styled('div', {
+  whiteSpace: 'pre-wrap',
+  fontSize: '12vw',
+  '@bp2': {
+    fontSize: 'inherit',
+    whiteSpace: 'normal',
+  },
+});
+
+const Date = styled('div', {
+  fontSize: '8vw',
+
+  '@bp2': {
+    fontSize: 'inherit',
+  },
+});
+
+const Location = styled('div', {
+  fontSize: '6vw',
+
+  '@bp2': {
+    fontSize: 'inherit',
+  },
 });
 const Teaser = () => {
   return (
     <TextBox>
-      <div>다시, 우리, 파이썬</div>
-      <div>2023.08.11-13</div>
-      <div>COEX 그랜드볼룸 & 아셈볼룸</div>
+      <Title>{'다시, \n우리, \n파이썬'}</Title>
+      <Date>2023.08.11-13</Date>
+      <Location>COEX 그랜드볼룸 & 아셈볼룸</Location>
     </TextBox>
   );
 };

--- a/components/sponsor/SponsorTypeSelectForm.tsx
+++ b/components/sponsor/SponsorTypeSelectForm.tsx
@@ -22,7 +22,10 @@ const RadioGroup = styled('div', {
   flexDirection: 'row',
   flexWrap: 'wrap',
   gap: '1rem',
-  margin: '2rem',
+
+  '@bp2': {
+    margin: '2rem',
+  },
 
   '& > *': {
     flex: '1 1 calc(50% - 1rem)',

--- a/components/sponsor/information/SponsorSimpleCard.tsx
+++ b/components/sponsor/information/SponsorSimpleCard.tsx
@@ -8,7 +8,6 @@ const CardWrapper = styled('div', {
   width: '100%',
 
   '@bp1': {
-    maxWidth: '300px',
     maxHeight: '300px',
     padding: '1rem 1rem',
   },

--- a/pages/coc/[pid].tsx
+++ b/pages/coc/[pid].tsx
@@ -20,6 +20,8 @@ const Layout = styled('div', {
   height: '100%',
   maxWidth: '1280px',
   margin: '0 auto',
+  paddingLeft: '2rem',
+  paddingRight: '2rem',
 });
 
 const StyledH1 = styled(H1, {
@@ -34,16 +36,26 @@ const SubText = styled('div', {
 });
 
 const Container = styled('div', {
-  marginTop: '90px',
   display: 'flex',
+  flexDirection: 'column',
   width: '100%',
+  marginTop: 40,
+  paddingBottom: 40,
+  '@bp2': {
+    marginTop: '90px',
+    flexDirection: 'row',
+  },
 });
 
 const Content = styled('div', {
-  marginLeft: '62px',
-  marginBottom: '100px',
   flex: 'auto',
+  marginTop: 24,
   borderTop: '2px solid $textPrimary',
+  '@bp2': {
+    marginTop: 0,
+    marginLeft: '62px',
+    marginBottom: '100px',
+  },
 });
 
 const CoCSubPage: NextPage<DocumentProps> = ({ document }) => {

--- a/pages/sponsor/join/index.tsx
+++ b/pages/sponsor/join/index.tsx
@@ -21,7 +21,14 @@ import { styled } from 'stitches.config';
 const Container = styled('div', {
   height: '100%',
   maxWidth: '630px',
+  paddingLeft: '2rem',
+  paddingRight: '2rem',
   margin: '0 auto',
+
+  '@bp2': {
+    paddingLeft: 0,
+    paddingRight: 0,
+  },
 });
 
 const SponsorJoinPage: NextPage<


### PR DESCRIPTION
컨텐츠의 너비가 모바일 뷰포트를 넘어가는 문제를 해결했습니다.

⚠️ 메인 페이지는 모바일 뷰포트에서 기존 타이포 형태 그대로 담기가 어려워 임의로 수정을 했습니다. 확인 부탁드려요.