### PR TITLE
feat: 모바일 네비게이션바 구현

### DIFF
--- a/components/layout/Container.tsx
+++ b/components/layout/Container.tsx
@@ -4,6 +4,7 @@ import NavBar from './NavBar';
 const ContainerBody = styled('div', {
   maxWidth: '1920px',
   margin: '0 auto',
+  padding: '0 20px',
   height: '100%',
 });
 

--- a/components/layout/NavBar.tsx
+++ b/components/layout/NavBar.tsx
@@ -1,12 +1,11 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { styled } from 'stitches.config';
 import Link from 'next/link';
 import { NavBarMenus, Routes } from '@/constants/routes';
 import { StyledButton } from '../common/Button';
 import { Logo as LogoSvg } from '@/public/icons';
-import { HamburgerIcon } from '@/public/icons';
-import { CloseIcon } from '@/public/icons';
 import ThemeSwitch from '../ThemeSwitch';
+import NavBarMobile from './NavBarMobile';
 
 const StyledNavArea = styled('div', {
   position: 'fixed',
@@ -103,38 +102,14 @@ const SolidButton = styled(StyledButton, {
   },
 });
 
-const MenuIconWrapper = styled('div', {
-  display: 'flex',
-  justifyContent: 'center',
-  alignContent: 'center',
-  width: '35px',
-  height: '35px',
-  cursor: 'pointer',
-  '@bp2': {
-    display: 'none',
-  },
-});
-
 const NavBar = () => {
-  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
-
-  const handleMobileMenuClick = () => {
-    setIsMobileMenuOpen((prev) => !prev);
-  };
-
   return (
     <StyledNavArea>
       <Link href={Routes.HOME.route} passHref>
         <Logo width={230} height={'100%'} />
         <Title>{Routes.HOME.title}</Title>
       </Link>
-      <MenuIconWrapper onClick={handleMobileMenuClick}>
-        {isMobileMenuOpen ? (
-          <CloseIcon width="30" height="30" />
-        ) : (
-          <HamburgerIcon width="30" height="30" />
-        )}
-      </MenuIconWrapper>
+      <NavBarMobile />
       <NavContainer>
         <StyledMenuBox>
           {NavBarMenus.map((menu) => (

--- a/components/layout/NavBar.tsx
+++ b/components/layout/NavBar.tsx
@@ -17,6 +17,7 @@ const StyledNavArea = styled('div', {
   width: '100%',
   height: '80px',
   margin: '0 auto',
+  paddingRight: '30px',
   zIndex: '99',
 
   '@bp2': {

--- a/components/layout/NavBar.tsx
+++ b/components/layout/NavBar.tsx
@@ -90,16 +90,8 @@ const SolidButton = styled(StyledButton, {
   color: '$backgroundPrimary',
   border: 'none',
   fontWeight: 700,
-
-  '@bp1': {
-    fontSize: '18px',
-    lineHeight: '18px',
-  },
-
-  '@bp2': {
-    fontSize: '24px',
-    lineHeight: '24px',
-  },
+  fontSize: '24px',
+  lineHeight: '24px',
 });
 
 const NavBar = () => {

--- a/components/layout/NavBar.tsx
+++ b/components/layout/NavBar.tsx
@@ -1,9 +1,11 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { styled } from 'stitches.config';
 import Link from 'next/link';
 import { NavBarMenus, Routes } from '@/constants/routes';
 import { StyledButton } from '../common/Button';
 import { Logo as LogoSvg } from '@/public/icons';
+import { HamburgerIcon } from '@/public/icons';
+import { CloseIcon } from '@/public/icons';
 import ThemeSwitch from '../ThemeSwitch';
 
 const StyledNavArea = styled('div', {
@@ -16,12 +18,8 @@ const StyledNavArea = styled('div', {
   width: '100%',
   height: '80px',
   margin: '0 auto',
-  zIndex: '9999',
+  zIndex: '99',
 
-  '@bp1': {
-    padding: '0 0.5rem',
-    gap: 0,
-  },
   '@bp2': {
     padding: '1rem 2rem',
   },
@@ -29,10 +27,14 @@ const StyledNavArea = styled('div', {
 
 const Logo = styled(LogoSvg, {
   display: 'block',
-  maxWidth: 230,
+  maxWidth: 180,
   width: '100%',
   '& path': {
     fill: '$textPrimary',
+  },
+
+  '@bp2': {
+    maxWidth: 230,
   },
 });
 
@@ -44,34 +46,26 @@ const Title = styled('h1', {
   clipPath: 'rect(0, 0, 0, 0)',
 });
 
+const NavContainer = styled('div', {
+  display: 'none',
+  '@bp2': {
+    display: 'flex',
+  },
+});
+
 const MenuItem = styled('span', {
   fontWeight: 700,
   color: '$textPrimary',
-
-  '@bp1': {
-    fontSize: '18px',
-    lineHeight: '18px',
-  },
-
-  '@bp2': {
-    fontSize: '24px',
-    lineHeight: '24px',
-  },
+  fontSize: '24px',
+  lineHeight: '24px',
 });
 
 const StyledMenuBox = styled('div', {
   display: 'flex',
-
-  '@bp1': {
-    padding: '0',
-    gap: '13px',
-  },
-  '@bp2': {
-    flex: 1,
-    alignItems: 'flex-start',
-    padding: '0 60px',
-    gap: '32px',
-  },
+  flex: 1,
+  alignItems: 'flex-start',
+  padding: '0 60px',
+  gap: '32px',
 });
 
 const StyledMenu = styled('div', {
@@ -88,23 +82,7 @@ const StyledMenu = styled('div', {
 const SideBox = styled('div', {
   display: 'flex',
   alignItems: 'center',
-
-  '@bp1': {
-    gap: 0,
-  },
-
-  '@bp2': {
-    gap: 40,
-  },
-});
-
-const SwitchWrapper = styled('div', {
-  '@bp1': {
-    display: 'none',
-  },
-  '@bp2': {
-    display: 'block',
-  },
+  gap: 40,
 });
 
 const SolidButton = styled(StyledButton, {
@@ -125,30 +103,57 @@ const SolidButton = styled(StyledButton, {
   },
 });
 
+const MenuIconWrapper = styled('div', {
+  display: 'flex',
+  justifyContent: 'center',
+  alignContent: 'center',
+  width: '35px',
+  height: '35px',
+  cursor: 'pointer',
+  '@bp2': {
+    display: 'none',
+  },
+});
+
 const NavBar = () => {
+  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+
+  const handleMobileMenuClick = () => {
+    setIsMobileMenuOpen((prev) => !prev);
+  };
+
   return (
     <StyledNavArea>
       <Link href={Routes.HOME.route} passHref>
         <Logo width={230} height={'100%'} />
         <Title>{Routes.HOME.title}</Title>
       </Link>
-      <StyledMenuBox>
-        {NavBarMenus.map((menu) => (
-          <StyledMenu key={menu.route}>
-            <Link href={menu.route} passHref>
-              <MenuItem>{menu.title}</MenuItem>
-            </Link>
-          </StyledMenu>
-        ))}
-      </StyledMenuBox>
-      <SideBox>
-        <SwitchWrapper>
+      <MenuIconWrapper onClick={handleMobileMenuClick}>
+        {isMobileMenuOpen ? (
+          <CloseIcon width="30" height="30" />
+        ) : (
+          <HamburgerIcon width="30" height="30" />
+        )}
+      </MenuIconWrapper>
+      <NavContainer>
+        <StyledMenuBox>
+          {NavBarMenus.map((menu) => (
+            <StyledMenu key={menu.route}>
+              <Link href={menu.route} passHref>
+                <MenuItem>{menu.title}</MenuItem>
+              </Link>
+            </StyledMenu>
+          ))}
+        </StyledMenuBox>
+        <SideBox>
           <ThemeSwitch />
-        </SwitchWrapper>
-        <Link href={Routes.SPONSOR_JOIN.route} passHref>
-          <SolidButton size={'small'}>{Routes.SPONSOR_JOIN.title}</SolidButton>
-        </Link>
-      </SideBox>
+          <Link href={Routes.SPONSOR_JOIN.route} passHref>
+            <SolidButton size={'small'}>
+              {Routes.SPONSOR_JOIN.title}
+            </SolidButton>
+          </Link>
+        </SideBox>
+      </NavContainer>
     </StyledNavArea>
   );
 };

--- a/components/layout/NavBarMobile.tsx
+++ b/components/layout/NavBarMobile.tsx
@@ -1,10 +1,11 @@
-import { NavBarMenus } from '@/constants/routes';
+import { NavBarMenus, Routes } from '@/constants/routes';
 import { styled } from '@/stitches.config';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import React, { useEffect, useState } from 'react';
 import { HamburgerIcon } from '@/public/icons';
 import { CloseIcon } from '@/public/icons';
+import { StyledButton } from '../common';
 
 const Container = styled('div', {
   display: 'block',
@@ -48,6 +49,19 @@ const MenuIconWrapper = styled('div', {
   zIndex: '101',
 });
 
+const SolidButton = styled(StyledButton, {
+  height: 40,
+  backgroundColor: '$textPrimary',
+  color: '$backgroundPrimary',
+  border: 'none',
+  fontWeight: 700,
+
+  '@bp1': {
+    fontSize: '18px',
+    lineHeight: '18px',
+  },
+});
+
 const NavBarMobile = () => {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const { pathname } = useRouter();
@@ -77,6 +91,11 @@ const NavBarMobile = () => {
                 <MenuItem>{menu.title}</MenuItem>
               </Link>
             ))}
+            <Link href={Routes.SPONSOR_JOIN.route} passHref>
+              <SolidButton size={'small'}>
+                {Routes.SPONSOR_JOIN.title}
+              </SolidButton>
+            </Link>
           </MenuContainer>
         </ForeGroundContainer>
       )}

--- a/components/layout/NavBarMobile.tsx
+++ b/components/layout/NavBarMobile.tsx
@@ -1,0 +1,87 @@
+import { NavBarMenus } from '@/constants/routes';
+import { styled } from '@/stitches.config';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+import React, { useEffect, useState } from 'react';
+import { HamburgerIcon } from '@/public/icons';
+import { CloseIcon } from '@/public/icons';
+
+const Container = styled('div', {
+  display: 'block',
+  '@bp2': {
+    display: 'none',
+  },
+});
+
+const ForeGroundContainer = styled('div', {
+  position: 'fixed',
+  top: '80px',
+  left: '0',
+  width: '100%',
+  height: '100%',
+  backgroundColor: '$backgroundPrimary',
+  zIndex: '100',
+});
+
+const MenuContainer = styled('div', {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '30px',
+  margin: '10px 0',
+  padding: '30px',
+});
+
+const MenuItem = styled('span', {
+  fontWeight: 700,
+  color: '$textPrimary',
+  fontSize: '24px',
+  lineHeight: '24px',
+});
+
+const MenuIconWrapper = styled('div', {
+  display: 'flex',
+  justifyContent: 'center',
+  alignContent: 'center',
+  width: '35px',
+  height: '35px',
+  cursor: 'pointer',
+  zIndex: '101',
+});
+
+const NavBarMobile = () => {
+  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+  const { pathname } = useRouter();
+
+  const handleMobileMenuClick = () => {
+    setIsMobileMenuOpen((prev) => !prev);
+  };
+
+  useEffect(() => {
+    setIsMobileMenuOpen(false);
+  }, [pathname, setIsMobileMenuOpen]);
+
+  return (
+    <Container>
+      <MenuIconWrapper onClick={handleMobileMenuClick}>
+        {isMobileMenuOpen ? (
+          <CloseIcon width="30" height="30" />
+        ) : (
+          <HamburgerIcon width="30" height="30" />
+        )}
+      </MenuIconWrapper>
+      {isMobileMenuOpen && (
+        <ForeGroundContainer>
+          <MenuContainer>
+            {NavBarMenus.map((menu) => (
+              <Link key={menu.route} href={menu.route} passHref>
+                <MenuItem>{menu.title}</MenuItem>
+              </Link>
+            ))}
+          </MenuContainer>
+        </ForeGroundContainer>
+      )}
+    </Container>
+  );
+};
+
+export default NavBarMobile;

--- a/public/icons/HamburgerIcon.svg
+++ b/public/icons/HamburgerIcon.svg
@@ -1,0 +1,5 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M2 8H14" stroke="#4F4F4F" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M2 4H14" stroke="#4F4F4F" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M2 12H14" stroke="#4F4F4F" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/icons/index.ts
+++ b/public/icons/index.ts
@@ -8,6 +8,7 @@ import PdfFileSubmitIcon from './PdfFileSubmitIcon.svg';
 import ImageFileSubmitIcon from './ImageFileSubmitIcon.svg';
 import CheckIconDark from './CheckIconDark.svg';
 import CheckIconLight from './CheckIconLight.svg';
+import HamburgerIcon from './HamburgerIcon.svg';
 
 export {
   CloseIcon,
@@ -20,4 +21,5 @@ export {
   ImageFileSubmitIcon,
   CheckIconDark,
   CheckIconLight,
+  HamburgerIcon,
 };


### PR DESCRIPTION
### 작업사항
- 모바일에서 네비게이션바 메뉴버튼(햄버거 버튼)으로 변경
- 모바일 네비게이션 메뉴 클릭 시 네비게이션 모달 나타나도록 구현
- 전체 Container에 padding 추가
### 스크린샷
<img width="477" alt="image" src="https://user-images.githubusercontent.com/50133823/227702683-c8747889-f102-4355-acbb-2c101f63cdce.png">
<img width="471" alt="image" src="https://user-images.githubusercontent.com/50133823/227702693-60f9eda7-b3f3-49e4-9a59-112c8893ad77.png">

### 참고사항
- 모바일 디자인이 따로 없는것 같아서 작년 홈페이지 디자인을 참고해서 작업했습니다. 혹시 디자인 수정이 필요하시면 말씀해주세요!
  그리고 햄버거 아이콘을 임의로 제가 가지고 있던걸로 사용했는데, 사용하시는 아이콘이 있다면 말씀해주시면 감사하겠습니다.