### PR TITLE
후원사 구좌 페이지 “취소선” 및 금액 “마감”표시

### DIFF
--- a/components/common/Table.tsx
+++ b/components/common/Table.tsx
@@ -1,4 +1,7 @@
-import { SponsorLevelRow } from '@/constants/sponsor/sponsorLevel';
+import {
+  SponsorLevelRow,
+  SponsorLevelStatus,
+} from '@/constants/sponsor/sponsorLevel';
 import { styled } from 'stitches.config';
 import React from 'react';
 import { TableOptions, useTable } from 'react-table';
@@ -39,6 +42,14 @@ const StyledTh = styled('th', {
   color: '$backgroundPrimary',
   fontSize: '1.5rem',
   fontWeight: '700',
+
+  variants: {
+    expired: {
+      true: {
+        textDecoration: 'line-through',
+      },
+    },
+  },
 });
 
 const TBodyText = styled('span', {
@@ -55,18 +66,27 @@ const CheckboxIcon = styled(CheckIconDark, {
 const Table = ({ columns, data }: TableOptions<object>) => {
   const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow } =
     useTable({ columns, data });
+
   return (
     <StyledTable {...getTableProps()}>
       <thead>
         {headerGroups.map((header) => {
-          const { key, ...restHeaderGroupProps } = header.getHeaderGroupProps();
+          const { key: headerKey, ...restHeaderGroupProps } =
+            header.getHeaderGroupProps();
+
           return (
-            <tr key={key} {...restHeaderGroupProps}>
+            <tr key={headerKey} {...restHeaderGroupProps}>
               <StyledTh />
               {header.headers.map((col) => {
-                const { key, ...restColumn } = col.getHeaderProps();
+                const { key: colKey, ...restColumn } = col.getHeaderProps();
                 return (
-                  <StyledTh key={key} {...restColumn}>
+                  <StyledTh
+                    key={colKey}
+                    expired={
+                      col.render('status') === SponsorLevelStatus.Expired
+                    }
+                    {...restColumn}
+                  >
                     {col.render('Header')}
                   </StyledTh>
                 );
@@ -76,22 +96,32 @@ const Table = ({ columns, data }: TableOptions<object>) => {
         })}
       </thead>
       <tbody {...getTableBodyProps()}>
-        {rows.map((row: any) => {
+        {rows.map((row) => {
           prepareRow(row);
           const { key, ...restRow } = row.getRowProps();
+          // REVIEW - map 에서 받아오는 두 번째 매개 변수인 index로는 안 되는 걸까?
           const i = rows.indexOf(row);
+
           return (
             <tr key={key} {...restRow}>
               <StyledTd key={i}>
                 <TBodyText>{SponsorLevelRow[i]}</TBodyText>
               </StyledTd>
-              {row.cells.map((cell: any) => {
+
+              {row.cells.map((cell) => {
                 const { value } = cell;
                 const { key: cellKey, ...restCell } = cell.getCellProps();
+
+                const cellText =
+                  cell.column.render('status') === SponsorLevelStatus.Expired &&
+                  SponsorLevelRow[i] === '후원금'
+                    ? '마감'
+                    : cell.render('Cell');
+
                 return (
                   <StyledTd key={cellKey} {...restCell}>
                     {typeof value === 'boolean' && value && <CheckboxIcon />}
-                    <TBodyText>{cell.render('Cell')}</TBodyText>
+                    <TBodyText>{cellText}</TBodyText>
                   </StyledTd>
                 );
               })}

--- a/components/common/Table.tsx
+++ b/components/common/Table.tsx
@@ -42,14 +42,6 @@ const StyledTh = styled('th', {
   color: '$backgroundPrimary',
   fontSize: '1.5rem',
   fontWeight: '700',
-
-  variants: {
-    expired: {
-      true: {
-        textDecoration: 'line-through',
-      },
-    },
-  },
 });
 
 const TBodyText = styled('span', {
@@ -80,13 +72,7 @@ const Table = ({ columns, data }: TableOptions<object>) => {
               {header.headers.map((col) => {
                 const { key: colKey, ...restColumn } = col.getHeaderProps();
                 return (
-                  <StyledTh
-                    key={colKey}
-                    expired={
-                      col.render('status') === SponsorLevelStatus.Expired
-                    }
-                    {...restColumn}
-                  >
+                  <StyledTh key={colKey} {...restColumn}>
                     {col.render('Header')}
                   </StyledTh>
                 );

--- a/constants/sponsor/sponsorLevel.ts
+++ b/constants/sponsor/sponsorLevel.ts
@@ -54,7 +54,7 @@ export const SponsorLevelColumn2: SponsorLevelColumn[] = [
   {
     accessor: 'gold',
     Header: '골드',
-    status: SponsorLevelStatus.Active,
+    status: SponsorLevelStatus.Expired,
   },
   {
     accessor: 'silver',

--- a/constants/sponsor/sponsorLevel.ts
+++ b/constants/sponsor/sponsorLevel.ts
@@ -11,49 +11,70 @@ export const SponsorLevelRow = [
   '로고 노출 위치',
 ];
 
-export const SponsorLevelColumn1 = [
+export enum SponsorLevelStatus {
+  Active = 'active',
+  Expired = 'expired',
+}
+
+export interface SponsorLevelColumn {
+  accessor: string;
+  Header: string;
+  status: SponsorLevelStatus;
+}
+
+export const SponsorLevelColumn1: SponsorLevelColumn[] = [
   {
     accessor: 'keystone',
     Header: '키스톤',
+    status: SponsorLevelStatus.Active,
   },
   {
     accessor: 'diamond',
     Header: '다이아몬드',
+    status: SponsorLevelStatus.Active,
   },
   {
     accessor: 'sapphire',
     Header: '사파이어',
+    status: SponsorLevelStatus.Expired,
   },
   {
     accessor: 'platinum',
     Header: '플레티넘',
+    status: SponsorLevelStatus.Active,
   },
   {
     accessor: 'ruby',
     Header: '루비',
+    status: SponsorLevelStatus.Active,
   },
 ];
 
-export const SponsorLevelColumn2 = [
+export const SponsorLevelColumn2: SponsorLevelColumn[] = [
   {
     accessor: 'gold',
     Header: '골드',
+    status: SponsorLevelStatus.Active,
   },
   {
     accessor: 'silver',
     Header: '실버',
+    status: SponsorLevelStatus.Active,
   },
   {
     accessor: 'startup',
     Header: '스타트업',
+    status: SponsorLevelStatus.Active,
   },
   {
     accessor: 'community',
     Header: '커뮤니티',
+    status: SponsorLevelStatus.Active,
   },
   {
     accessor: 'publisher',
     Header: '출판사',
+    status: SponsorLevelStatus.Active,
   },
 ];
 


### PR DESCRIPTION
# 작업사항
- 후원사 구좌 페이지 “취소선” 및 금액 “마감”표시
- `sponsorLevel.ts`의 `SponsorLevelColumn1, 2` 에서 `status` 부분만 바꿔주면 알아서 바뀌도록 변경
- 오타 방지를 위해 `enum SponsorLevelStatus` 추가

# 스크린샷
![image](https://user-images.githubusercontent.com/35517199/233378660-7049baa3-c2a2-421e-b77c-afac3267a25f.png)
![image](https://user-images.githubusercontent.com/35517199/233378731-e278790d-f067-40e8-b522-904250afcb78.png)


# 참고사항
- 후원사 등급 안내 테이블은 여기 밖에 없겠죠?
- 일단 `sponsorLevel.ts` 안에서 쓰인 `enum` 과 `interface`를 해당 파일에 그대로 작성하였는데, 해당 타이핑들의 이동이 필요하면 자유롭게 해주시길 바랍니다!