### PR TITLE
후원사 모집 기간 및 후원금 수정

### DIFF
--- a/components/common/Table.tsx
+++ b/components/common/Table.tsx
@@ -100,7 +100,7 @@ const Table = ({ columns, data }: TableOptions<object>) => {
 
                 const cellText =
                   cell.column.render('status') === SponsorLevelStatus.Expired &&
-                  SponsorLevelRow[i] === '후원금'
+                  SponsorLevelRow[i] === '스폰서 수'
                     ? '마감'
                     : cell.render('Cell');
 

--- a/components/sponsor/information/Main.tsx
+++ b/components/sponsor/information/Main.tsx
@@ -8,7 +8,7 @@ import * as S from './styles';
 export const Main = () => (
   <S.Section id="application">
     <H1>SPONSORS</H1>
-    <S.PeriodText>모집 기간: 2023.03.06 - 2023.05.01</S.PeriodText>
+    <S.PeriodText>모집 기간: 2023.03.06 - 2023.06.02</S.PeriodText>
     <S.SponsorActionButtonWrapper>
       <Link href={Routes.SPONSOR_JOIN.route}>
         <Button reversal>파이콘 후원하기</Button>


### PR DESCRIPTION
# 액션
- [x]  메인 페이지의 모집 기간을 `2023.03.06 - 2023.05.01` 에서 `2023.03.06 - 2023.06.02` 으로 변경
- [x]  테이블에서 스폰서 레벨별 마감시 마감표시되는 row를 `후원금`에서 `스폰서 수`로 변경

## 변경 전 UI
### 후원사 메인 페이지 상단
<img width="1431" alt="스크린샷 2023-04-26 오후 6 42 11" src="https://user-images.githubusercontent.com/97649363/234536997-f92ff13e-a824-400e-b276-cc010cbac39f.png">

### 후원사 테이블 
<img width="1418" alt="image" src="https://user-images.githubusercontent.com/97649363/234537150-e9d2f0f8-61c4-4964-a275-c9c93c0af9d1.png">

## 변경 후 UI
### 후원사 메인 페이지 상단
<img width="1712" alt="스크린샷 2023-04-26 오후 6 45 24" src="https://user-images.githubusercontent.com/97649363/234537850-9e9df601-751d-4fce-ad1c-89dfe8b3a588.png">

### 후원사 테이블 
<img width="995" alt="image" src="https://user-images.githubusercontent.com/97649363/234536923-fbfb853f-561a-4638-9a98-2166783eda26.png">
