### PR TITLE
모바일 메뉴에 빠진 후원안내 추가!

### DIFF
--- a/constants/routes.ts
+++ b/constants/routes.ts
@@ -6,11 +6,11 @@ export const Routes: { [key: string]: RouteType } = {
     route: '/',
   },
   COC: {
-    title: '행동 강령',
+    title: '행동강령',
     route: '/coc',
   },
   SPONSOR_INFO: {
-    title: '후원 안내',
+    title: '후원안내',
     route: '/sponsor/information',
   },
   SPONSOR_JOIN: {
@@ -18,7 +18,7 @@ export const Routes: { [key: string]: RouteType } = {
     route: '/sponsor/join',
   },
   CFP_APPLY: {
-    title: '발표 제안',
+    title: '발표제안',
     route: '/cfp/apply',
   },
 };
@@ -28,5 +28,6 @@ export const MobileNavBarMenus = [
   // TODO: 이거 추가하기 => Routes.PROGRAM ,
   Routes.CFP_APPLY,
   Routes.COC,
+  Routes.SPONSOR_INFO,
   Routes.SPONSOR_JOIN,
 ];


### PR DESCRIPTION
## 상황
- 모바일 화면 메뉴에 후원하기만 있고 후원안내가 없어서 추가했습니다~

## 캡쳐화면
![image](https://user-images.githubusercontent.com/48143796/234608123-ee32dcbd-fcf3-4ab9-aaf4-66790ef177fd.png)

