### PR TITLE
데스크탑 Navbar 메뉴 중앙정렬

### DIFF
--- a/components/layout/NavBar.tsx
+++ b/components/layout/NavBar.tsx
@@ -66,7 +66,7 @@ const MenuItem = styled('span', {
 const StyledMenuBox = styled('div', {
   display: 'flex',
   flex: 1,
-  alignItems: 'flex-start',
+  alignItems: 'center',
   padding: '0 60px',
   gap: '32px',
 });


### PR DESCRIPTION
## 작업사항
- 데스크탑 Navbar 메뉴가 피그마 디자인과 다르게 상단 정렬이 되어 있어 중앙 정렬로 수정했습니다.

### 기존

<img width="1374" alt="image" src="https://user-images.githubusercontent.com/50133823/234619633-5b31f75e-20e8-4bb7-83e7-50df872a1625.png">

### 수정 후

<img width="1387" alt="image" src="https://user-images.githubusercontent.com/50133823/234619702-dcc8fd93-c686-4b1a-b2fd-f58ab8c4e195.png">
