### PR TITLE
스프린트 모집 안내 페이지 추가

### DIFF
--- a/constants/routes.ts
+++ b/constants/routes.ts
@@ -8,6 +8,7 @@ const routeKeys = [
   'SPONSOR_JOIN',
   'CFP_APPLY',
   'TUTORIAL_APPLY',
+  'SPRINT_APPLY',
   'LOGIN',
   'TICKET',
   'TICKET_DETAIL',
@@ -40,6 +41,10 @@ export const Routes: { [key in (typeof routeKeys)[number]]: RouteType } = {
     title: '튜토리얼',
     route: '/tutorials/apply',
   },
+  SPRINT_APPLY: {
+    title: '스프린트',
+    route: '/sprint/apply',
+  },
   LOGIN: {
     title: '로그인',
     route: '/login',
@@ -66,12 +71,12 @@ export const NavBarMenus = [
   Routes.COC,
   Routes.SPONSOR_INFO,
   Routes.CFP_APPLY,
-  Routes.TUTORIAL_APPLY,
+  Routes.SPRINT_APPLY,
 ].concat(isEnvProd() ? [] : [Routes.TICKET]);
 export const MobileNavBarMenus = [
   // TODO: 이거 추가하기 => Routes.PROGRAM ,
   Routes.CFP_APPLY,
-  Routes.TUTORIAL_APPLY,
+  Routes.SPRINT_APPLY,
   Routes.COC,
   Routes.SPONSOR_INFO,
   Routes.SPONSOR_JOIN,

--- a/pages/sprint/apply.tsx
+++ b/pages/sprint/apply.tsx
@@ -1,0 +1,131 @@
+import type { GetStaticProps, NextPage } from 'next';
+import SeoHeader from '@/components/layout/SeoHeader';
+import { Routes } from '@/constants/routes';
+import { H1, H2, H3, H4 } from '@/components/heading';
+import path from 'path';
+import fs from 'fs';
+import ReactMarkdown from 'react-markdown';
+import {
+  Paragraph,
+  UnorderedList,
+  OrderedList,
+  ListItem,
+  StyledLink,
+  StyledH3,
+} from '@/components/common/Markdown';
+import * as S from '@/components/sponsor/information/styles';
+import remarkGfm from 'remark-gfm';
+import { styled } from 'stitches.config';
+
+interface PageProps {
+  sprintGuide: string;
+  formUrl: string;
+}
+
+const ApplyPageContainer = styled('div', {
+  bodyText: 1,
+});
+
+const Block = styled('div', {});
+// TODO: 컴포넌트 폴더로 옮기기
+const LinkButton = styled('a', {
+  bodyText: 1,
+  width: '160px',
+  padding: '8px',
+  display: 'inline-block',
+  textAlign: 'center',
+  variants: {
+    reversal: {
+      true: {
+        color: '$backgroundPrimary',
+        backgroundColor: '$textPrimary',
+      },
+      false: {
+        color: '$textPrimary',
+        backgroundColor: '$backgroundPrimary',
+      },
+    },
+  },
+});
+
+const sprintApplyPage: NextPage<PageProps> = ({ sprintGuide, formUrl }) => {
+  return (
+    <ApplyPageContainer>
+      <SeoHeader
+        title={Routes.SPRINT_APPLY.title}
+        description="파이콘 한국 2023: 8월 11~13일 코엑스"
+      />
+      <S.Section>
+        <div>
+          <H1>스프린트 진행자 모집</H1>
+          <Block css={{ marginTop: '16px' }}>
+            스프린트는 관심있는 오픈소스 프로젝트를 같은 장소에 모여 집중적으로
+            개발하는 자리입니다. <br />
+            새로운 동료를 만나고, 오픈소스에서 얻을 수 있는 경험과 지식을 나눌
+            수 있는 시간입니다. <br />
+            처음 참여하신다고요? 문제 없습니다. 해당 프로젝트를 주도적으로
+            개발하는 분에게 배울 수 있는 시간이 될 것입니다. <br />
+            💌 오픈소스 프로젝트에 기여하고자 하시는 분들은 스프린트 진행자로
+            많이 지원해주세요!
+          </Block>
+          <Block css={{ marginTop: '16px' }}>
+            <LinkButton target="_blank" href={formUrl} reversal={true}>
+              신청하기
+            </LinkButton>
+          </Block>
+          <Block css={{ marginTop: '64px' }}>
+            <H2>스프린트 진행일 및 장소</H2>
+            <div style={{ marginTop: '8px' }}>
+              2023년 8월 11일 금요일 / 코엑스(Coex) 아셈볼룸 - 컨퍼런스룸(북)
+            </div>
+          </Block>
+          <Block css={{ marginTop: '64px' }}>
+            <H2>모집 일정</H2>
+            <div style={{ marginTop: '8px' }}>
+              ~ 2023년 6월 25일 일요일 (23:50 GMT+9)
+            </div>
+          </Block>
+        </div>
+        <Block css={{ marginTop: '104px' }}>
+          <ReactMarkdown
+            components={{
+              h1: ({ node, ...props }) => <H2 {...props} />,
+              h2: ({ node, ...props }) => <StyledH3 {...props} />,
+              h3: ({ node, ...props }) => <H4 {...props} />,
+              p: ({ node, ...props }) => <Paragraph {...props} />,
+              ol: ({ node, ...props }) => <OrderedList {...props} />,
+              ul: ({ node, ...props }) => <UnorderedList {...props} />,
+              li: ({ node, ...props }) => <ListItem {...props} />,
+              a: ({ node, ...props }) => <StyledLink {...props} />,
+            }}
+            remarkPlugins={[remarkGfm]}
+          >
+            {sprintGuide}
+          </ReactMarkdown>
+        </Block>
+        <Block css={{ margin: '104px 0 64px' }}>
+          <H2>문의</H2>
+          <Block css={{ marginTop: '16px' }}>program@pycon.kr</Block>
+        </Block>
+      </S.Section>
+    </ApplyPageContainer>
+  );
+};
+
+export const getStaticProps: GetStaticProps<{
+  sprintGuide: string;
+}> = async () => {
+  const staticPath = path.join(process.cwd(), 'static');
+  const sprintGuidePath = path.join(staticPath, 'sprint-apply-guide.md');
+  const sprintGuide = fs.readFileSync(sprintGuidePath, 'utf8');
+  const formUrl = 'https://forms.gle/tiaBc3ydhmiecknG9';
+
+  return {
+    props: {
+      sprintGuide,
+      formUrl,
+    },
+  };
+};
+
+export default sprintApplyPage;

--- a/static/sprint-apply-guide.md
+++ b/static/sprint-apply-guide.md
@@ -1,0 +1,14 @@
+# 지난 스프린트
+
+🔎 지난 파이콘 프로그램을 통해 스프린트 프로그램이 어떻게 진행되었는지 참고해보세요!
+- [PyCon Korea 2018](https://archive.pycon.kr/2018/program/sprint/)
+- [PyCon Korea 2017](https://archive.pycon.kr/2017/program/tutorials/)
+- [PyCon US 2019](https://us.pycon.org/2019/community/sprints/)
+- [스프린트/튜토리얼의 대장이 되어보자](http://blog.pycon.kr/2017/07/11/tutorial-and-sprint/)
+
+# 참고사항
+
++ ✔️ 파이썬을 이용해야 합니다.
++ ✔️ 진행자는 파이콘 기간 동안에 [파이콘 한국 행동강령](/coc)을 지켜야 합니다.
++ ✔️ 대한민국 실정법에 위반이 없어야 합니다.
++ ✔️ 스프린트는 파이콘 한국 컨퍼런스 티켓을 구매하지 않더라도 참가가 가능합니다.


### PR DESCRIPTION
## 작업내용
+ 스프린트 모집 안내 페이지를 제작하였습니다. (튜토리얼 모집 안내 페이지를 기반)
+ 네비게이션 바의 튜토리얼 배너를 스프린트로 변경하였습니다.

