### PR TITLE
대문 페이지에 티켓 구매 버튼 추가

### DIFF
--- a/components/main/Teaser.tsx
+++ b/components/main/Teaser.tsx
@@ -10,7 +10,7 @@ const TextBox = styled('div', {
   height: 'calc(100vh - 80px)',
 
   '@bp2': {
-    paddingTop: 220,
+    paddingTop: 70,
     paddingLeft: 40,
     paddingRight: 40,
   },
@@ -41,12 +41,44 @@ const Location = styled('div', {
     fontSize: 'inherit',
   },
 });
+
+const Block = styled('div', {});
+
+const LinkButton = styled('a', {
+  bodyText: 1,
+  width: '160px',
+  padding: '8px',
+  display: 'inline-block',
+  textAlign: 'center',
+  variants: {
+    reversal: {
+      true: {
+        color: '$backgroundPrimary',
+        backgroundColor: '$textPrimary',
+      },
+      false: {
+        color: '$textPrimary',
+        backgroundColor: '$backgroundPrimary',
+      },
+    },
+  },
+});
+
 const Teaser = () => {
   return (
     <TextBox>
       <Title>{'다시, \n우리, \n파이썬'}</Title>
       <Date>2023.08.11-13</Date>
       <Location>COEX 그랜드볼룸 & 아셈볼룸</Location>
+      <Block css={{ marginTop: '16px' }}>
+        <LinkButton
+          target="_blank"
+          href="https://event-us.kr/pyconkr/event/65861"
+          reversal={true}
+        >
+          티켓 구매
+        </LinkButton>
+      </Block>
     </TextBox>
   );
 };


### PR DESCRIPTION
대문 페이지에 티켓 구매 페이지로 이동하는 버튼을 추가합니다.

# 적용 스크린샷
![image](https://github.com/pythonkr/pyconkr-2023-frontend/assets/76910100/5cc01388-b305-4d5f-9422-fb91c5e65eba)
